### PR TITLE
Implement GLTF model rendering with material system and mesh renderer

### DIFF
--- a/shaders/fragment.wgsl
+++ b/shaders/fragment.wgsl
@@ -1,14 +1,18 @@
 struct VertexOut 
 {
-    @builtin(position) pos: vec4f,
-    @location(0) texCoord: vec2f
+    @builtin(position) positionCS: vec4f,
+    @location(0) texCoord: vec2f,
+    @location(1) normalOS: vec3f
 };
 
-// @group(0) @binding(0) var _sampler: sampler;
-// @group(0) @binding(1) var _texture: texture_2d<f32>;
+// 注意：binding 0 被 uniform buffer 占用，binding 1 被 storage buffer 占用
+// 纹理从 binding 2 开始
+@group(0) @binding(2) var diffuse_texture: texture_2d<f32>;
+@group(0) @binding(3) var diffuse_sampler: sampler;
 
 @fragment 
 fn fs_main(in: VertexOut) -> @location(0) vec4f 
 {
-    return vec4f(in.texCoord, 0.0f, 1.0f); // textureSample(_texture, _sampler, in.texCoord);
+    let textureColor = textureSample(diffuse_texture, diffuse_sampler, in.texCoord);
+    return textureColor;
 }

--- a/shaders/vertex.wgsl
+++ b/shaders/vertex.wgsl
@@ -1,38 +1,70 @@
- // data structure to store output of vertex function
+// Uniform buffer 结构
+struct Uniforms {
+    mvpMatrix: mat4x4<f32>,
+};
+
+// 绑定 uniform buffer
+@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+
+// 顶点数据 storage buffer（显式读取方式）
+@group(0) @binding(1) var<storage, read> vertexData: array<f32>;
+
+// 顶点数据结构（匹配 Mesh 类中的 VertexData）
+struct VertexData {
+    position: vec3f,    // 位置 (3 floats)
+    normal: vec3f,      // 法线 (3 floats)
+    uv0: vec2f,         // 纹理坐标 (2 floats)
+};
+
+// data structure to store output of vertex function
 struct VertexOut 
 {
-    @builtin(position) pos: vec4f,
-    @location(0) texCoord: vec2f
+    @builtin(position) positionCS: vec4f,
+    @location(0) texCoord: vec2f,
+    @location(1) normalOS: vec3f
 };
 
-struct VertexData {
-    position: vec3f,
-    normal: vec3f,
-    uv0: vec2f,
-};
+// 顶点布局常量（匹配 Mesh 类中的 VERTEX_LAYOUT）
+const VERTEX_STRIDE: u32 = 8u;  // 8 floats per vertex (position:3 + normal:3 + uv:2)
 
-@group(0) @binding(0)
-var<storage> vertexBuffer: array<f32>;
-
-@group(0) @binding(1)
-var<storage> indexBuffer: array<u32>;
-
+// 从 storage buffer 读取顶点数据并封装为 VertexData 结构体
 fn getVertexData(vertexIndex: u32) -> VertexData {
-    let offset = vertexIndex * 8u;
-    let position = vec3f(vertexBuffer[offset + 0u], vertexBuffer[offset + 1u], vertexBuffer[offset + 2u]);
-    let normal = vec3f(vertexBuffer[offset + 3u], vertexBuffer[offset + 4u], vertexBuffer[offset + 5u]);
-    let uv0 = vec2f(vertexBuffer[offset + 6u], vertexBuffer[offset + 7u]);
-    return VertexData(position, normal, uv0);
+    let offset = vertexIndex * VERTEX_STRIDE;
+    
+    var vertex: VertexData;
+    vertex.position = vec3f(
+        vertexData[offset + 0u],
+        vertexData[offset + 1u], 
+        vertexData[offset + 2u]
+    );
+    vertex.normal = vec3f(
+        vertexData[offset + 3u],
+        vertexData[offset + 4u],
+        vertexData[offset + 5u]
+    );
+    vertex.uv0 = vec2f(
+        vertexData[offset + 6u],
+        vertexData[offset + 7u]
+    );
+    
+    return vertex;
 }
 
 // process the points of the triangle
 @vertex 
-fn vs_main(@builtin(vertex_index) vertexIndex : u32) -> VertexOut 
+fn vs_main(@builtin(vertex_index) vertexIndex: u32) -> VertexOut 
 {
     var out: VertexOut;
-    let vertexData = getVertexData(indexBuffer[vertexIndex]);
-    out.pos = vec4f(vertexData.position, 1.0f);
-    out.texCoord = vertexData.uv0;
+    
+    // 从 storage buffer 读取顶点数据
+    let vertex = getVertexData(vertexIndex);
+    
+    // 应用 MVP 变换到位置
+    out.positionCS = uniforms.mvpMatrix * vec4f(vertex.position, 1.0f);
+    out.texCoord = vertex.uv0;
+    
+    // 传递对象空间法线
+    out.normalOS = vertex.normal;
 
     return out;
 }

--- a/src/material.ts
+++ b/src/material.ts
@@ -1,0 +1,663 @@
+import { Texture, TextureFromURLOptions } from './texture';
+import { GraphicsPipeline, GraphicsPipelineOptions } from './graphics-pipeline';
+
+/**
+ * 材质纹理槽配置
+ */
+export interface MaterialTextureSlot {
+  /** 纹理对象 */
+  texture: Texture;
+  /** 采样器描述符 */
+  samplerDescriptor?: GPUSamplerDescriptor;
+  /** 绑定组中的绑定索引 */
+  binding: number;
+  /** 纹理类型标识 */
+  name: string;
+}
+
+/**
+ * 材质Uniform缓冲区配置
+ */
+export interface MaterialUniformBuffer {
+  /** 缓冲区对象 */
+  buffer: GPUBuffer;
+  /** 绑定组中的绑定索引 */
+  binding: number;
+  /** 缓冲区名称 */
+  name: string;
+  /** 缓冲区大小 */
+  size: number;
+}
+
+/**
+ * 材质Storage缓冲区配置
+ */
+export interface MaterialStorageBuffer {
+  /** 缓冲区对象（可以是 GPUBuffer 或 GPUBufferWrapper） */
+  buffer: GPUBuffer | import('./gpu-buffer').GPUBufferWrapper;
+  /** 绑定组中的绑定索引 */
+  binding: number;
+  /** 缓冲区名称 */
+  name: string;
+  /** 缓冲区大小 */
+  size: number;
+}
+
+/**
+ * 材质配置选项
+ */
+export interface MaterialOptions {
+  /** 材质名称 */
+  name?: string;
+  /** 顶点着色器代码 */
+  vertexShaderCode: string;
+  /** 片元着色器代码 */
+  fragmentShaderCode: string;
+  /** 纹理槽映射 */
+  textures?: Map<string, MaterialTextureSlot>;
+  /** Uniform缓冲区映射 */
+  uniforms?: Map<string, MaterialUniformBuffer>;
+  /** Storage缓冲区映射 */
+  storageBuffers?: Map<string, MaterialStorageBuffer>;
+  /** 图形管线配置选项 */
+  pipelineOptions?: Partial<GraphicsPipelineOptions>;
+}
+
+/**
+ * 材质类
+ * 管理着色器、纹理和Uniform参数的完整材质系统
+ */
+export class Material {
+  private device: GPUDevice;
+  private name: string;
+  private pipeline: GraphicsPipeline;
+  private textures: Map<string, MaterialTextureSlot>;
+  private uniforms: Map<string, MaterialUniformBuffer>;
+  private storageBuffers: Map<string, MaterialStorageBuffer>;
+  private bindGroup: GPUBindGroup | null = null;
+  private bindGroupLayout: GPUBindGroupLayout | null = null;
+
+  constructor(device: GPUDevice, options: MaterialOptions) {
+    this.device = device;
+    this.name = options.name || 'Material';
+    this.textures = options.textures || new Map();
+    this.uniforms = options.uniforms || new Map();
+    this.storageBuffers = options.storageBuffers || new Map();
+
+    // 创建绑定组布局
+    this.bindGroupLayout = this.createBindGroupLayout();
+
+    // 创建图形管线
+    const pipelineOptions: GraphicsPipelineOptions = {
+      ...options.pipelineOptions,
+      vertexShaderCode: options.vertexShaderCode,
+      fragmentShaderCode: options.fragmentShaderCode,
+      bindGroupLayouts: this.bindGroupLayout ? [this.bindGroupLayout] : undefined,
+      label: `${this.name}-pipeline`
+    };
+
+    this.pipeline = new GraphicsPipeline(device, pipelineOptions);
+
+    // 创建绑定组
+    this.bindGroup = this.createBindGroup();
+  }
+
+  /**
+   * 创建绑定组布局
+   */
+  private createBindGroupLayout(): GPUBindGroupLayout | null {
+    const entries: GPUBindGroupLayoutEntry[] = [];
+
+    // 添加纹理绑定
+    this.textures.forEach((slot) => {
+      // 纹理绑定
+      entries.push({
+        binding: slot.binding,
+        visibility: GPUShaderStage.FRAGMENT,
+        texture: {
+          sampleType: 'float',
+          viewDimension: '2d'
+        }
+      });
+
+      // 采样器绑定
+      entries.push({
+        binding: slot.binding + 1,
+        visibility: GPUShaderStage.FRAGMENT,
+        sampler: {}
+      });
+    });
+
+    // 添加Uniform缓冲区绑定
+    this.uniforms.forEach((uniform) => {
+      entries.push({
+        binding: uniform.binding,
+        visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+        buffer: {
+          type: 'uniform'
+        }
+      });
+    });
+
+    // 添加Storage缓冲区绑定
+    this.storageBuffers.forEach((storageBuffer) => {
+      entries.push({
+        binding: storageBuffer.binding,
+        visibility: GPUShaderStage.VERTEX | GPUShaderStage.FRAGMENT,
+        buffer: {
+          type: 'read-only-storage'
+        }
+      });
+    });
+
+    if (entries.length === 0) {
+      return null;
+    }
+
+    return this.device.createBindGroupLayout({
+      label: `${this.name}-bind-group-layout`,
+      entries
+    });
+  }
+
+  /**
+   * 创建绑定组
+   */
+  private createBindGroup(): GPUBindGroup | null {
+    if (!this.bindGroupLayout) {
+      return null;
+    }
+
+    const entries: GPUBindGroupEntry[] = [];
+
+    // 添加纹理绑定
+    this.textures.forEach((slot) => {
+      // 纹理绑定
+      entries.push({
+        binding: slot.binding,
+        resource: slot.texture.getView()
+      });
+
+      // 采样器绑定
+      let sampler = slot.texture.getSampler();
+      if (!sampler) {
+        sampler = slot.texture.createSampler(slot.samplerDescriptor);
+      }
+
+      entries.push({
+        binding: slot.binding + 1,
+        resource: sampler
+      });
+    });
+
+    // 添加Uniform缓冲区绑定
+    this.uniforms.forEach((uniform) => {
+      entries.push({
+        binding: uniform.binding,
+        resource: {
+          buffer: uniform.buffer
+        }
+      });
+    });
+
+    // 添加Storage缓冲区绑定
+    this.storageBuffers.forEach((storageBuffer) => {
+      const buffer = 'getBuffer' in storageBuffer.buffer 
+        ? storageBuffer.buffer.getBuffer() 
+        : storageBuffer.buffer;
+      
+      entries.push({
+        binding: storageBuffer.binding,
+        resource: {
+          buffer: buffer
+        }
+      });
+    });
+
+    return this.device.createBindGroup({
+      label: `${this.name}-bind-group`,
+      layout: this.bindGroupLayout,
+      entries
+    });
+  }
+
+  /**
+   * 重新创建绑定组（在纹理或Uniform更新后调用）
+   */
+  private rebuildBindGroup(): void {
+    this.bindGroupLayout = this.createBindGroupLayout();
+    this.bindGroup = this.createBindGroup();
+
+    // 重新创建管线以使用新的绑定组布局
+    const options = this.pipeline.getOptions();
+    const newPipelineOptions: GraphicsPipelineOptions = {
+      ...options,
+      bindGroupLayouts: this.bindGroupLayout ? [this.bindGroupLayout] : undefined
+    };
+
+    this.pipeline = new GraphicsPipeline(this.device, newPipelineOptions);
+  }
+
+  /**
+   * 设置纹理
+   */
+  setTexture(
+    name: string,
+    texture: Texture,
+    binding: number,
+    samplerDescriptor?: GPUSamplerDescriptor
+  ): void {
+    const slot: MaterialTextureSlot = {
+      texture,
+      binding,
+      name,
+      samplerDescriptor
+    };
+
+    this.textures.set(name, slot);
+    this.rebuildBindGroup();
+  }
+
+  /**
+   * 从URL加载并设置纹理
+   */
+  async setTextureFromURL(
+    name: string,
+    url: string,
+    binding: number,
+    textureOptions?: TextureFromURLOptions,
+    samplerDescriptor?: GPUSamplerDescriptor
+  ): Promise<void> {
+    const texture = await Texture.fromURL(this.device, url, textureOptions);
+    this.setTexture(name, texture, binding, samplerDescriptor);
+  }
+
+  /**
+   * 设置纯色纹理
+   */
+  setSolidColorTexture(
+    name: string,
+    color: [number, number, number, number],
+    binding: number,
+    size: [number, number] = [1, 1],
+    samplerDescriptor?: GPUSamplerDescriptor
+  ): void {
+    const texture = Texture.createSolidColor(
+      this.device,
+      color,
+      size[0],
+      size[1],
+      `${this.name}-${name}-texture`
+    );
+    this.setTexture(name, texture, binding, samplerDescriptor);
+  }
+
+  /**
+   * 移除纹理
+   */
+  removeTexture(name: string): boolean {
+    const removed = this.textures.delete(name);
+    if (removed) {
+      this.rebuildBindGroup();
+    }
+    return removed;
+  }
+
+  /**
+   * 获取纹理
+   */
+  getTexture(name: string): Texture | undefined {
+    return this.textures.get(name)?.texture;
+  }
+
+  /**
+   * 设置Uniform缓冲区
+   */
+  setUniformBuffer(name: string, buffer: GPUBuffer, binding: number, size: number): void {
+    const uniform: MaterialUniformBuffer = {
+      buffer,
+      binding,
+      name,
+      size
+    };
+
+    this.uniforms.set(name, uniform);
+    this.rebuildBindGroup();
+  }
+
+  /**
+   * 创建并设置Uniform缓冲区
+   */
+  createUniformBuffer(name: string, data: ArrayBufferView, binding: number): GPUBuffer {
+    const buffer = this.device.createBuffer({
+      label: `${this.name}-${name}-uniform`,
+      size: data.byteLength,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
+    });
+
+    this.device.queue.writeBuffer(buffer, 0, data);
+    this.setUniformBuffer(name, buffer, binding, data.byteLength);
+
+    return buffer;
+  }
+
+  /**
+   * 更新Uniform缓冲区数据
+   */
+  updateUniformBuffer(name: string, data: ArrayBufferView, offset: number = 0): boolean {
+    const uniform = this.uniforms.get(name);
+    if (!uniform) {
+      return false;
+    }
+
+    this.device.queue.writeBuffer(uniform.buffer, offset, data);
+    return true;
+  }
+
+  /**
+   * 移除Uniform缓冲区
+   */
+  removeUniformBuffer(name: string): boolean {
+    const removed = this.uniforms.delete(name);
+    if (removed) {
+      this.rebuildBindGroup();
+    }
+    return removed;
+  }
+
+  /**
+   * 获取Uniform缓冲区
+   */
+  getUniformBuffer(name: string): GPUBuffer | undefined {
+    return this.uniforms.get(name)?.buffer;
+  }
+
+  /**
+   * 设置Storage缓冲区
+   */
+  setStorageBuffer(
+    name: string, 
+    buffer: GPUBuffer | import('./gpu-buffer').GPUBufferWrapper, 
+    binding: number
+  ): void {
+    const actualBuffer = 'getBuffer' in buffer ? buffer.getBuffer() : buffer;
+    const size = 'getSize' in buffer ? buffer.getSize() : 0;
+    
+    const storageBuffer: MaterialStorageBuffer = {
+      buffer,
+      binding,
+      name,
+      size
+    };
+
+    this.storageBuffers.set(name, storageBuffer);
+    this.rebuildBindGroup();
+  }
+
+  /**
+   * 移除Storage缓冲区
+   */
+  removeStorageBuffer(name: string): boolean {
+    const removed = this.storageBuffers.delete(name);
+    if (removed) {
+      this.rebuildBindGroup();
+    }
+    return removed;
+  }
+
+  /**
+   * 获取Storage缓冲区
+   */
+  getStorageBuffer(name: string): GPUBuffer | import('./gpu-buffer').GPUBufferWrapper | undefined {
+    return this.storageBuffers.get(name)?.buffer;
+  }
+
+  /**
+   * 获取所有Storage缓冲区名称
+   */
+  getStorageBufferNames(): string[] {
+    return Array.from(this.storageBuffers.keys());
+  }
+
+  /**
+   * 绑定材质到渲染通道
+   */
+  bind(renderPass: GPURenderPassEncoder): void {
+    // 绑定管线
+    this.pipeline.bind(renderPass);
+
+    // 绑定资源
+    if (this.bindGroup) {
+      renderPass.setBindGroup(0, this.bindGroup);
+    }
+  }
+
+  /**
+   * 获取图形管线
+   */
+  getPipeline(): GraphicsPipeline {
+    return this.pipeline;
+  }
+
+  /**
+   * 获取绑定组
+   */
+  getBindGroup(): GPUBindGroup | null {
+    return this.bindGroup;
+  }
+
+  /**
+   * 获取绑定组布局
+   */
+  getBindGroupLayout(): GPUBindGroupLayout | null {
+    return this.bindGroupLayout;
+  }
+
+  /**
+   * 获取材质名称
+   */
+  getName(): string {
+    return this.name;
+  }
+
+  /**
+   * 获取所有纹理名称
+   */
+  getTextureNames(): string[] {
+    return Array.from(this.textures.keys());
+  }
+
+  /**
+   * 获取所有Uniform缓冲区名称
+   */
+  getUniformNames(): string[] {
+    return Array.from(this.uniforms.keys());
+  }
+
+  /**
+   * 克隆材质（浅拷贝纹理和Uniform）
+   */
+  clone(newName?: string): Material {
+    const clonedTextures = new Map(this.textures);
+    const clonedUniforms = new Map(this.uniforms);
+    const originalOptions = this.pipeline.getOptions();
+
+    return new Material(this.device, {
+      name: newName || `${this.name}-clone`,
+      vertexShaderCode: originalOptions.vertexShaderCode,
+      fragmentShaderCode: originalOptions.fragmentShaderCode,
+      textures: clonedTextures,
+      uniforms: clonedUniforms,
+      pipelineOptions: originalOptions
+    });
+  }
+
+  /**
+   * 销毁材质资源
+   */
+  destroy(): void {
+    // 销毁纹理
+    this.textures.forEach((slot) => {
+      slot.texture.destroy();
+    });
+    this.textures.clear();
+
+    // 销毁Uniform缓冲区
+    this.uniforms.forEach((uniform) => {
+      uniform.buffer.destroy();
+    });
+    this.uniforms.clear();
+
+    // 清理管线
+    this.pipeline.destroy();
+
+    // 清空引用
+    this.bindGroup = null;
+    this.bindGroupLayout = null;
+  }
+
+  /**
+   * 静态方法：创建基础材质
+   */
+  static createBasic(
+    device: GPUDevice,
+    vertexShaderCode: string,
+    fragmentShaderCode: string,
+    options?: Partial<MaterialOptions>
+  ): Material {
+    return new Material(device, {
+      vertexShaderCode,
+      fragmentShaderCode,
+      ...options
+    });
+  }
+
+  /**
+   * 静态方法：创建带单张纹理的材质
+   */
+  static async createWithTexture(
+    device: GPUDevice,
+    vertexShaderCode: string,
+    fragmentShaderCode: string,
+    textureUrl: string,
+    options?: Partial<MaterialOptions>
+  ): Promise<Material> {
+    const material = new Material(device, {
+      vertexShaderCode,
+      fragmentShaderCode,
+      ...options
+    });
+
+    await material.setTextureFromURL('diffuse', textureUrl, 0);
+    return material;
+  }
+
+  /**
+   * 静态方法：创建标准PBR材质
+   */
+  static async createPBR(
+    device: GPUDevice,
+    vertexShaderCode: string,
+    fragmentShaderCode: string,
+    texturePaths: {
+      albedo?: string;
+      normal?: string;
+      metallic?: string;
+      roughness?: string;
+      ao?: string;
+    },
+    options?: Partial<MaterialOptions>
+  ): Promise<Material> {
+    const material = new Material(device, {
+      vertexShaderCode,
+      fragmentShaderCode,
+      name: 'PBR-Material',
+      ...options
+    });
+
+    let binding = 0;
+
+    if (texturePaths.albedo) {
+      await material.setTextureFromURL('albedo', texturePaths.albedo, binding);
+      binding += 2; // 纹理+采样器占用2个绑定
+    }
+
+    if (texturePaths.normal) {
+      await material.setTextureFromURL('normal', texturePaths.normal, binding);
+      binding += 2;
+    }
+
+    if (texturePaths.metallic) {
+      await material.setTextureFromURL('metallic', texturePaths.metallic, binding);
+      binding += 2;
+    }
+
+    if (texturePaths.roughness) {
+      await material.setTextureFromURL('roughness', texturePaths.roughness, binding);
+      binding += 2;
+    }
+
+    if (texturePaths.ao) {
+      await material.setTextureFromURL('ao', texturePaths.ao, binding);
+      binding += 2;
+    }
+
+    return material;
+  }
+}
+
+/**
+ * 材质库类
+ * 管理多个材质的集合
+ */
+export class MaterialLibrary {
+  private materials: Map<string, Material> = new Map();
+
+  /**
+   * 添加材质
+   */
+  addMaterial(name: string, material: Material): void {
+    this.materials.set(name, material);
+  }
+
+  /**
+   * 获取材质
+   */
+  getMaterial(name: string): Material | undefined {
+    return this.materials.get(name);
+  }
+
+  /**
+   * 移除材质
+   */
+  removeMaterial(name: string): boolean {
+    const material = this.materials.get(name);
+    if (material) {
+      material.destroy();
+      return this.materials.delete(name);
+    }
+    return false;
+  }
+
+  /**
+   * 获取所有材质名称
+   */
+  getMaterialNames(): string[] {
+    return Array.from(this.materials.keys());
+  }
+
+  /**
+   * 清空材质库
+   */
+  clear(): void {
+    this.materials.forEach(material => material.destroy());
+    this.materials.clear();
+  }
+
+  /**
+   * 获取材质数量
+   */
+  size(): number {
+    return this.materials.size;
+  }
+}

--- a/src/math/float4x4.ts
+++ b/src/math/float4x4.ts
@@ -1,12 +1,466 @@
-export class float4x4 
-{
-    public elements: number[];
-    public constructor() {
-        this.elements = [
-            1, 0, 0, 0,
-            0, 1, 0, 0,
-            0, 0, 1, 0,
-            0, 0, 0, 1
-        ];
-    }
+import { float3 } from './float3';
+
+/**
+ * 4x4 矩阵类
+ * 用于 3D 变换（模型、视图、投影矩阵）
+ * 
+ * 存储格式：列主序（column-major），与 WebGPU/WGSL 一致
+ * 内存布局：
+ * [m0, m1, m2, m3,   <- 第一列 (x轴或第一列向量)
+ *  m4, m5, m6, m7,   <- 第二列 (y轴或第二列向量)
+ *  m8, m9, m10, m11, <- 第三列 (z轴或第三列向量)
+ *  m12, m13, m14, m15] <- 第四列 (平移或第四列向量)
+ */
+export class float4x4 {
+  public elements: number[];
+
+  /**
+   * 创建一个单位矩阵
+   */
+  constructor() {
+    this.elements = [
+      1, 0, 0, 0,
+      0, 1, 0, 0,
+      0, 0, 1, 0,
+      0, 0, 0, 1
+    ];
+  }
+
+  /**
+   * 设置矩阵元素
+   */
+  set(
+    m0: number, m1: number, m2: number, m3: number,
+    m4: number, m5: number, m6: number, m7: number,
+    m8: number, m9: number, m10: number, m11: number,
+    m12: number, m13: number, m14: number, m15: number
+  ): this {
+    this.elements = [
+      m0, m1, m2, m3,
+      m4, m5, m6, m7,
+      m8, m9, m10, m11,
+      m12, m13, m14, m15
+    ];
+    return this;
+  }
+
+  /**
+   * 克隆矩阵
+   */
+  clone(): float4x4 {
+    const result = new float4x4();
+    result.elements = [...this.elements];
+    return result;
+  }
+
+  /**
+   * 复制另一个矩阵
+   */
+  copy(m: float4x4): this {
+    this.elements = [...m.elements];
+    return this;
+  }
+
+  /**
+   * 设置为单位矩阵
+   */
+  identity(): this {
+    this.elements = [
+      1, 0, 0, 0,
+      0, 1, 0, 0,
+      0, 0, 1, 0,
+      0, 0, 0, 1
+    ];
+    return this;
+  }
+
+  /**
+   * 矩阵乘法（左乘）
+   * this = this * m
+   */
+  multiply(m: float4x4): this {
+    const result = float4x4.multiply(this, m);
+    this.elements = result.elements;
+    return this;
+  }
+
+  /**
+   * 矩阵乘法（右乘）
+   * this = m * this
+   */
+  premultiply(m: float4x4): this {
+    const result = float4x4.multiply(m, this);
+    this.elements = result.elements;
+    return this;
+  }
+
+  /**
+   * 转置矩阵
+   */
+  transpose(): this {
+    const e = this.elements;
+    let temp: number;
+
+    temp = e[1]; e[1] = e[4]; e[4] = temp;
+    temp = e[2]; e[2] = e[8]; e[8] = temp;
+    temp = e[3]; e[3] = e[12]; e[12] = temp;
+    temp = e[6]; e[6] = e[9]; e[9] = temp;
+    temp = e[7]; e[7] = e[13]; e[13] = temp;
+    temp = e[11]; e[11] = e[14]; e[14] = temp;
+
+    return this;
+  }
+
+  /**
+   * 转换为数组
+   */
+  toArray(): number[] {
+    return [...this.elements];
+  }
+
+  /**
+   * 转换为 Float32Array（用于 GPU 上传）
+   */
+  toFloat32Array(): Float32Array {
+    return new Float32Array(this.elements);
+  }
+
+  // ========== 静态工厂方法 ==========
+
+  /**
+   * 创建单位矩阵
+   */
+  static identity(): float4x4 {
+    return new float4x4();
+  }
+
+  /**
+   * 创建平移矩阵
+   */
+  static translation(x: number, y: number, z: number): float4x4 {
+    const result = new float4x4();
+    result.elements[12] = x;
+    result.elements[13] = y;
+    result.elements[14] = z;
+    return result;
+  }
+
+  /**
+   * 创建平移矩阵（从向量）
+   */
+  static translationFromVector(v: float3): float4x4 {
+    return float4x4.translation(v.x, v.y, v.z);
+  }
+
+  /**
+   * 创建缩放矩阵
+   */
+  static scaling(x: number, y: number, z: number): float4x4 {
+    const result = new float4x4();
+    result.elements[0] = x;
+    result.elements[5] = y;
+    result.elements[10] = z;
+    return result;
+  }
+
+  /**
+   * 创建均匀缩放矩阵
+   */
+  static uniformScaling(s: number): float4x4 {
+    return float4x4.scaling(s, s, s);
+  }
+
+  /**
+   * 创建绕 X 轴旋转的矩阵
+   * @param angleRadians 旋转角度（弧度）
+   */
+  static rotationX(angleRadians: number): float4x4 {
+    const c = Math.cos(angleRadians);
+    const s = Math.sin(angleRadians);
+    const result = new float4x4();
+    
+    result.elements[5] = c;
+    result.elements[6] = s;
+    result.elements[9] = -s;
+    result.elements[10] = c;
+    
+    return result;
+  }
+
+  /**
+   * 创建绕 Y 轴旋转的矩阵
+   * @param angleRadians 旋转角度（弧度）
+   */
+  static rotationY(angleRadians: number): float4x4 {
+    const c = Math.cos(angleRadians);
+    const s = Math.sin(angleRadians);
+    const result = new float4x4();
+    
+    result.elements[0] = c;
+    result.elements[2] = -s;
+    result.elements[8] = s;
+    result.elements[10] = c;
+    
+    return result;
+  }
+
+  /**
+   * 创建绕 Z 轴旋转的矩阵
+   * @param angleRadians 旋转角度（弧度）
+   */
+  static rotationZ(angleRadians: number): float4x4 {
+    const c = Math.cos(angleRadians);
+    const s = Math.sin(angleRadians);
+    const result = new float4x4();
+    
+    result.elements[0] = c;
+    result.elements[1] = s;
+    result.elements[4] = -s;
+    result.elements[5] = c;
+    
+    return result;
+  }
+
+  /**
+   * 创建绕任意轴旋转的矩阵
+   * @param axis 旋转轴（需要归一化）
+   * @param angleRadians 旋转角度（弧度）
+   */
+  static rotationAxis(axis: float3, angleRadians: number): float4x4 {
+    const c = Math.cos(angleRadians);
+    const s = Math.sin(angleRadians);
+    const t = 1 - c;
+    
+    const x = axis.x;
+    const y = axis.y;
+    const z = axis.z;
+    
+    const result = new float4x4();
+    const e = result.elements;
+    
+    e[0] = t * x * x + c;
+    e[1] = t * x * y + s * z;
+    e[2] = t * x * z - s * y;
+    e[3] = 0;
+    
+    e[4] = t * x * y - s * z;
+    e[5] = t * y * y + c;
+    e[6] = t * y * z + s * x;
+    e[7] = 0;
+    
+    e[8] = t * x * z + s * y;
+    e[9] = t * y * z - s * x;
+    e[10] = t * z * z + c;
+    e[11] = 0;
+    
+    e[12] = 0;
+    e[13] = 0;
+    e[14] = 0;
+    e[15] = 1;
+    
+    return result;
+  }
+
+  /**
+   * 创建欧拉角旋转矩阵（XYZ 顺序）
+   * @param x 绕 X 轴旋转角度（弧度）
+   * @param y 绕 Y 轴旋转角度（弧度）
+   * @param z 绕 Z 轴旋转角度（弧度）
+   */
+  static rotationEulerXYZ(x: number, y: number, z: number): float4x4 {
+    const rx = float4x4.rotationX(x);
+    const ry = float4x4.rotationY(y);
+    const rz = float4x4.rotationZ(z);
+    
+    // 组合顺序：先 X，然后 Y，最后 Z
+    return float4x4.multiply(float4x4.multiply(rz, ry), rx);
+  }
+
+  /**
+   * 矩阵乘法
+   * 返回 a * b
+   */
+  static multiply(a: float4x4, b: float4x4): float4x4 {
+    const ae = a.elements;
+    const be = b.elements;
+    const result = new float4x4();
+    const re = result.elements;
+
+    const a00 = ae[0], a01 = ae[1], a02 = ae[2], a03 = ae[3];
+    const a10 = ae[4], a11 = ae[5], a12 = ae[6], a13 = ae[7];
+    const a20 = ae[8], a21 = ae[9], a22 = ae[10], a23 = ae[11];
+    const a30 = ae[12], a31 = ae[13], a32 = ae[14], a33 = ae[15];
+
+    const b00 = be[0], b01 = be[1], b02 = be[2], b03 = be[3];
+    const b10 = be[4], b11 = be[5], b12 = be[6], b13 = be[7];
+    const b20 = be[8], b21 = be[9], b22 = be[10], b23 = be[11];
+    const b30 = be[12], b31 = be[13], b32 = be[14], b33 = be[15];
+
+    re[0] = a00 * b00 + a10 * b01 + a20 * b02 + a30 * b03;
+    re[1] = a01 * b00 + a11 * b01 + a21 * b02 + a31 * b03;
+    re[2] = a02 * b00 + a12 * b01 + a22 * b02 + a32 * b03;
+    re[3] = a03 * b00 + a13 * b01 + a23 * b02 + a33 * b03;
+
+    re[4] = a00 * b10 + a10 * b11 + a20 * b12 + a30 * b13;
+    re[5] = a01 * b10 + a11 * b11 + a21 * b12 + a31 * b13;
+    re[6] = a02 * b10 + a12 * b11 + a22 * b12 + a32 * b13;
+    re[7] = a03 * b10 + a13 * b11 + a23 * b12 + a33 * b13;
+
+    re[8] = a00 * b20 + a10 * b21 + a20 * b22 + a30 * b23;
+    re[9] = a01 * b20 + a11 * b21 + a21 * b22 + a31 * b23;
+    re[10] = a02 * b20 + a12 * b21 + a22 * b22 + a32 * b23;
+    re[11] = a03 * b20 + a13 * b21 + a23 * b22 + a33 * b23;
+
+    re[12] = a00 * b30 + a10 * b31 + a20 * b32 + a30 * b33;
+    re[13] = a01 * b30 + a11 * b31 + a21 * b32 + a31 * b33;
+    re[14] = a02 * b30 + a12 * b31 + a22 * b32 + a32 * b33;
+    re[15] = a03 * b30 + a13 * b31 + a23 * b32 + a33 * b33;
+
+    return result;
+  }
+
+  /**
+   * 创建透视投影矩阵
+   * @param fov 视野角度（弧度）
+   * @param aspect 宽高比
+   * @param near 近裁剪面距离
+   * @param far 远裁剪面距离
+   */
+  static perspective(fov: number, aspect: number, near: number, far: number): float4x4 {
+    const f = 1.0 / Math.tan(fov / 2);
+    const nf = 1 / (near - far);
+    
+    const result = new float4x4();
+    const e = result.elements;
+    
+    e[0] = f / aspect;
+    e[1] = 0;
+    e[2] = 0;
+    e[3] = 0;
+    
+    e[4] = 0;
+    e[5] = f;
+    e[6] = 0;
+    e[7] = 0;
+    
+    e[8] = 0;
+    e[9] = 0;
+    e[10] = (far + near) * nf;
+    e[11] = -1;
+    
+    e[12] = 0;
+    e[13] = 0;
+    e[14] = 2 * far * near * nf;
+    e[15] = 0;
+    
+    return result;
+  }
+
+  /**
+   * 创建正交投影矩阵
+   * @param left 左边界
+   * @param right 右边界
+   * @param bottom 下边界
+   * @param top 上边界
+   * @param near 近裁剪面
+   * @param far 远裁剪面
+   */
+  static orthographic(
+    left: number, right: number,
+    bottom: number, top: number,
+    near: number, far: number
+  ): float4x4 {
+    const w = 1.0 / (right - left);
+    const h = 1.0 / (top - bottom);
+    const d = 1.0 / (far - near);
+    
+    const result = new float4x4();
+    const e = result.elements;
+    
+    e[0] = 2 * w;
+    e[1] = 0;
+    e[2] = 0;
+    e[3] = 0;
+    
+    e[4] = 0;
+    e[5] = 2 * h;
+    e[6] = 0;
+    e[7] = 0;
+    
+    e[8] = 0;
+    e[9] = 0;
+    e[10] = -2 * d;
+    e[11] = 0;
+    
+    e[12] = -(right + left) * w;
+    e[13] = -(top + bottom) * h;
+    e[14] = -(far + near) * d;
+    e[15] = 1;
+    
+    return result;
+  }
+
+  /**
+   * 创建 lookAt 视图矩阵
+   * @param eye 相机位置
+   * @param target 目标位置
+   * @param up 上方向
+   */
+  static lookAt(eye: float3, target: float3, up: float3): float4x4 {
+    // 计算视图方向（z 轴）
+    const z = float3.sub(eye, target).normalize();
+    
+    // 计算右方向（x 轴）
+    const x = float3.cross(up.clone(), z).normalize();
+    
+    // 计算上方向（y 轴）
+    const y = float3.cross(z.clone(), x);
+    
+    const result = new float4x4();
+    const e = result.elements;
+    
+    e[0] = x.x;
+    e[1] = y.x;
+    e[2] = z.x;
+    e[3] = 0;
+    
+    e[4] = x.y;
+    e[5] = y.y;
+    e[6] = z.y;
+    e[7] = 0;
+    
+    e[8] = x.z;
+    e[9] = y.z;
+    e[10] = z.z;
+    e[11] = 0;
+    
+    e[12] = -float3.dot(x, eye);
+    e[13] = -float3.dot(y, eye);
+    e[14] = -float3.dot(z, eye);
+    e[15] = 1;
+    
+    return result;
+  }
+
+  /**
+   * 从数组创建矩阵
+   */
+  static fromArray(array: number[]): float4x4 {
+    const result = new float4x4();
+    result.elements = [...array];
+    return result;
+  }
+
+  /**
+   * 转换为字符串
+   */
+  toString(): string {
+    const e = this.elements;
+    return `float4x4(\n` +
+      `  ${e[0].toFixed(3)}, ${e[4].toFixed(3)}, ${e[8].toFixed(3)}, ${e[12].toFixed(3)}\n` +
+      `  ${e[1].toFixed(3)}, ${e[5].toFixed(3)}, ${e[9].toFixed(3)}, ${e[13].toFixed(3)}\n` +
+      `  ${e[2].toFixed(3)}, ${e[6].toFixed(3)}, ${e[10].toFixed(3)}, ${e[14].toFixed(3)}\n` +
+      `  ${e[3].toFixed(3)}, ${e[7].toFixed(3)}, ${e[11].toFixed(3)}, ${e[15].toFixed(3)}\n` +
+      `)`;
+  }
 }

--- a/src/mesh-renderer.ts
+++ b/src/mesh-renderer.ts
@@ -1,0 +1,356 @@
+import { Mesh } from './mesh';
+import { Material } from './material';
+import { Texture } from './texture';
+import { float4x4 } from './math/float4x4';
+
+/**
+ * MeshRenderer 类
+ * 封装 Mesh 和 Material 的组合，提供统一的渲染接口
+ */
+export class MeshRenderer {
+  private mesh: Mesh;
+  private material: Material;
+  private transform: float4x4;
+  private enabled: boolean;
+  private name: string;
+
+  constructor(
+    mesh: Mesh,
+    material: Material,
+    transform?: float4x4,
+    name?: string
+  ) {
+    this.mesh = mesh;
+    this.material = material;
+    this.transform = transform || new float4x4();
+    this.enabled = true;
+    this.name = name || 'MeshRenderer';
+  }
+
+  /**
+   * 渲染方法
+   * 统一处理 material 绑定、mesh 绑定和绘制调用
+   * @param renderPass 渲染通道编码器
+   * @param viewMatrix 相机视图矩阵
+   * @param projectionMatrix 投影矩阵
+   */
+  render(
+    renderPass: GPURenderPassEncoder,
+    viewMatrix: float4x4,
+    projectionMatrix: float4x4
+  ): void {
+    if (!this.enabled) {
+      return;
+    }
+
+    // 计算 MVP 矩阵 = Projection * View * Model
+    const mvp = float4x4.multiply(
+      float4x4.multiply(projectionMatrix, viewMatrix),
+      this.transform
+    );
+
+    // 更新材质的 MVP uniform buffer
+    const mvpData = mvp.toFloat32Array();
+    this.material.updateUniformBuffer('mvp', mvpData);
+
+    // 绑定材质（包括pipeline和资源）
+    // 注意：storage buffer 已经在创建时预先设置，无需在每次渲染时重新绑定
+    this.material.bind(renderPass);
+
+    // 绑定索引缓冲区
+    renderPass.setIndexBuffer(this.mesh.getIndexBuffer().getBuffer(), 'uint32');
+
+    // 执行绘制（使用索引绘制，不需要顶点缓冲区）
+    renderPass.drawIndexed(this.mesh.getIndexCount());
+  }
+
+  /**
+   * 设置新的网格
+   */
+  setMesh(mesh: Mesh): void {
+    this.mesh = mesh;
+  }
+
+  /**
+   * 设置新的材质
+   */
+  setMaterial(material: Material): void {
+    this.material = material;
+  }
+
+  /**
+   * 设置变换矩阵
+   */
+  setTransform(transform: float4x4): void {
+    this.transform = transform;
+  }
+
+  /**
+   * 获取变换矩阵
+   */
+  getTransform(): float4x4 {
+    return this.transform;
+  }
+
+  /**
+   * 启用/禁用渲染
+   */
+  setEnabled(enabled: boolean): void {
+    this.enabled = enabled;
+  }
+
+  /**
+   * 检查是否启用
+   */
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  /**
+   * 获取网格
+   */
+  getMesh(): Mesh {
+    return this.mesh;
+  }
+
+  /**
+   * 获取材质
+   */
+  getMaterial(): Material {
+    return this.material;
+  }
+
+  /**
+   * 获取名称
+   */
+  getName(): string {
+    return this.name;
+  }
+
+  /**
+   * 设置名称
+   */
+  setName(name: string): void {
+    this.name = name;
+  }
+
+  /**
+   * 销毁资源
+   */
+  destroy(): void {
+    // 注意：我们不销毁 mesh 和 material，因为它们可能被其他 MeshRenderer 共享
+    // 如果需要销毁，应该由外部代码负责
+  }
+
+  /**
+   * 静态工厂方法：从 GLTF 导入的数据创建 MeshRenderer
+   */
+  static async createFromGLTF(
+    device: GPUDevice,
+    meshData: Mesh,
+    textureData: Texture[],
+    vertexShaderCode: string,
+    fragmentShaderCode: string,
+    name?: string
+  ): Promise<MeshRenderer> {
+    // 预先准备所有绑定信息
+    const uniforms = new Map();
+    const storageBuffers = new Map();
+    const textures = new Map();
+
+    // 创建 MVP uniform buffer（64 字节 = 16 个 float32）
+    const mvpData = new Float32Array(16);
+    // 初始化为单位矩阵
+    mvpData[0] = 1; mvpData[5] = 1; mvpData[10] = 1; mvpData[15] = 1;
+    
+    const mvpBuffer = device.createBuffer({
+      label: `${name || 'GLTF'}-mvp-uniform`,
+      size: mvpData.byteLength,
+      usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
+    });
+    device.queue.writeBuffer(mvpBuffer, 0, mvpData);
+
+    uniforms.set('mvp', {
+      buffer: mvpBuffer,
+      binding: 0,
+      name: 'mvp',
+      size: mvpData.byteLength
+    });
+
+    // 设置顶点数据 storage buffer（binding 1）
+    const actualBuffer = 'getBuffer' in meshData.getVertexBuffer() 
+      ? meshData.getVertexBuffer().getBuffer() 
+      : meshData.getVertexBuffer();
+    const bufferSize = 'getSize' in meshData.getVertexBuffer() 
+      ? meshData.getVertexBuffer().getSize() 
+      : 0;
+
+    storageBuffers.set('vertexData', {
+      buffer: meshData.getVertexBuffer(),
+      binding: 1,
+      name: 'vertexData',
+      size: bufferSize
+    });
+
+    // 如果有纹理数据，设置第一个纹理作为漫反射纹理
+    // 注意：纹理从 binding 2 开始
+    if (textureData.length > 0) {
+      textures.set('diffuse', {
+        texture: textureData[0],
+        binding: 2,
+        name: 'diffuse'
+      });
+    }
+
+    // 一次性创建材质，包含所有绑定信息
+    const material = new Material(device, {
+      name: name ? `${name}-material` : 'GLTF-Material',
+      vertexShaderCode,
+      fragmentShaderCode,
+      uniforms,
+      storageBuffers,
+      textures,
+      pipelineOptions: {
+        cullMode: 'back',
+        frontFace: 'ccw',
+        depthCompare: 'less'
+        // 注意：移除了 vertexBufferLayouts，因为我们使用 storage buffer + vertex_index
+      }
+    });
+
+    // 创建 MeshRenderer
+    return new MeshRenderer(meshData, material, undefined, name);
+  }
+
+  /**
+   * 静态工厂方法：批量从 GLTF 导入的数据创建 MeshRenderer 数组
+   */
+  static async createArrayFromGLTF(
+    device: GPUDevice,
+    meshes: Mesh[],
+    textures: Texture[],
+    vertexShaderCode: string,
+    fragmentShaderCode: string,
+    namePrefix?: string
+  ): Promise<MeshRenderer[]> {
+    const renderers: MeshRenderer[] = [];
+
+    for (let i = 0; i < meshes.length; i++) {
+      const name = namePrefix ? `${namePrefix}-${i}` : `GLTF-Mesh-${i}`;
+      const renderer = await MeshRenderer.createFromGLTF(
+        device,
+        meshes[i],
+        textures,
+        vertexShaderCode,
+        fragmentShaderCode,
+        name
+      );
+      renderers.push(renderer);
+    }
+
+    return renderers;
+  }
+
+  /**
+   * 静态工厂方法：创建简单的 MeshRenderer（用于测试）
+   */
+  static createSimple(
+    device: GPUDevice,
+    mesh: Mesh,
+    vertexShaderCode: string,
+    fragmentShaderCode: string,
+    name?: string
+  ): MeshRenderer {
+    const material = Material.createBasic(
+      device,
+      vertexShaderCode,
+      fragmentShaderCode,
+      {
+        name: name ? `${name}-material` : 'Simple-Material'
+      }
+    );
+
+    return new MeshRenderer(mesh, material, undefined, name);
+  }
+}
+
+/**
+ * MeshRenderer 管理器
+ * 管理多个 MeshRenderer 的集合
+ */
+export class MeshRendererManager {
+  private renderers: Map<string, MeshRenderer> = new Map();
+
+  /**
+   * 添加 MeshRenderer
+   */
+  addRenderer(name: string, renderer: MeshRenderer): void {
+    this.renderers.set(name, renderer);
+  }
+
+  /**
+   * 获取 MeshRenderer
+   */
+  getRenderer(name: string): MeshRenderer | undefined {
+    return this.renderers.get(name);
+  }
+
+  /**
+   * 移除 MeshRenderer
+   */
+  removeRenderer(name: string): boolean {
+    return this.renderers.delete(name);
+  }
+
+  /**
+   * 获取所有 MeshRenderer
+   */
+  getAllRenderers(): MeshRenderer[] {
+    return Array.from(this.renderers.values());
+  }
+
+  /**
+   * 获取启用的 MeshRenderer
+   */
+  getEnabledRenderers(): MeshRenderer[] {
+    return Array.from(this.renderers.values()).filter(renderer => renderer.isEnabled());
+  }
+
+  /**
+   * 渲染所有启用的 MeshRenderer
+   * @param renderPass 渲染通道编码器
+   * @param viewMatrix 相机视图矩阵
+   * @param projectionMatrix 投影矩阵
+   */
+  renderAll(
+    renderPass: GPURenderPassEncoder,
+    viewMatrix: float4x4,
+    projectionMatrix: float4x4
+  ): void {
+    const enabledRenderers = this.getEnabledRenderers();
+    for (const renderer of enabledRenderers) {
+      renderer.render(renderPass, viewMatrix, projectionMatrix);
+    }
+  }
+
+  /**
+   * 清空所有 MeshRenderer
+   */
+  clear(): void {
+    this.renderers.clear();
+  }
+
+  /**
+   * 获取 MeshRenderer 数量
+   */
+  size(): number {
+    return this.renderers.size;
+  }
+
+  /**
+   * 获取所有 MeshRenderer 名称
+   */
+  getRendererNames(): string[] {
+    return Array.from(this.renderers.keys());
+  }
+}


### PR DESCRIPTION
## What's Changed

This PR adds basic GLTF model rendering support to the Veach engine.

### New Components

- __Material System__ (`src/material.ts`) - Manages textures and material properties for WebGPU rendering
- __Mesh Renderer__ (`src/mesh-renderer.ts`) - Handles mesh rendering with materials and transforms

### Enhanced Features

- __Math Library__ (`src/math/float4x4.ts`) - Added 4x4 matrix operations for transforms and camera matrices
- __Renderer__ (`src/renderer.ts`) - Updated to support material-based rendering pipeline

### Shader Improvements

- Updated variable naming to follow UE coordinate space conventions:

  - `pos` → `positionCS` (Clip Space)
  - `normal` → `normalOS` (Object Space)

This provides the foundation for loading and rendering GLTF models with basic material support.
